### PR TITLE
feat: setDownloadBehavior chromium request skippable by env variable

### DIFF
--- a/packages/playwright-core/src/server/chromium/crBrowser.ts
+++ b/packages/playwright-core/src/server/chromium/crBrowser.ts
@@ -348,13 +348,15 @@ export class CRBrowserContext extends BrowserContext {
   override async _initialize() {
     assert(!Array.from(this._browser._crPages.values()).some(page => page._browserContext === this));
     const promises: Promise<any>[] = [super._initialize()];
-    if (this._browser.options.name !== 'electron' && this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
-      promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
-        behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',
-        browserContextId: this._browserContextId,
-        downloadPath: this._browser.options.downloadsPath,
-        eventsEnabled: true,
-      }));
+    if (!process.env.PLAYWRIGHT_IGNORE_DOWNLOAD_BEHAVIOUR) {
+      if (this._browser.options.name !== 'electron' && this._browser.options.name !== 'clank' && this._options.acceptDownloads !== 'internal-browser-default') {
+        promises.push(this._browser._session.send('Browser.setDownloadBehavior', {
+          behavior: this._options.acceptDownloads === 'accept' ? 'allowAndName' : 'deny',
+          browserContextId: this._browserContextId,
+          downloadPath: this._browser.options.downloadsPath,
+          eventsEnabled: true,
+        }));
+      }
     }
     await Promise.all(promises);
   }


### PR DESCRIPTION
Change needed to work with `connectionOverCPD` with Chromium versions lower than v125.0.8